### PR TITLE
Regexp for top-level hidden files

### DIFF
--- a/index.js
+++ b/index.js
@@ -248,7 +248,7 @@ setTimeout(function() {
 	}
 
 	chokidar.watch(SOURCE_DIR, {
-		ignored: /[\/\\]\./,
+		ignored: /(^|[\/\\])\.(?!$)/,
 		persistent: true,
 		ignoreInitial: true
 	})


### PR DESCRIPTION
The current `ignored` path regexp doesn't catch hidden files on the top-level for the relative path, which causes issues when directory like `.git` is present.

This was the problem behind the issue #8, which causes `rbxrefresh` to lockup while trying to synchronize `.git` files.

Edit: Never mind, the #8 issue still occurs, so it's not related to syncing `.git` files.
